### PR TITLE
Combine the creation of ro and rw partition in one service file

### DIFF
--- a/activation.hpp
+++ b/activation.hpp
@@ -294,13 +294,9 @@ class Activation : public ActivationInherit
         /** @brief Used to subscribe to dbus systemd signals **/
         sdbusplus::bus::match_t systemdSignals;
 
-        /** @brief Tracks whether the squashfs image has been loaded as part of
-         * the activation process. **/
-        bool squashfsLoaded = false;
-
-        /** @brief Tracks whether the read-write volumes have been created as
-         * part of the activation process. **/
-        bool rwVolumesCreated = false;
+        /** @brief Tracks whether the read-only & read-write volumes have been
+         *created as part of the activation process. **/
+        bool ubiVolumesCreated = false;
 
         /** @brief activation status property get function
          *

--- a/item_updater.cpp
+++ b/item_updater.cpp
@@ -344,7 +344,7 @@ void ItemUpdater::erase(std::string entryId)
     // Remove priority persistence file
     removeFile(entryId);
 
-    // Removing partitions
+    // Removing read-only and read-write partitions
     removeReadWritePartition(entryId);
     removeReadOnlyPartition(entryId);
 

--- a/item_updater.hpp
+++ b/item_updater.hpp
@@ -141,7 +141,7 @@ class ItemUpdater : public ItemUpdaterInherit
         /** @brief Clears read write PNOR partition for
          *  given Activation dbus object
          *
-         * @param[in]  versionId - The id of the rw partition to remove.
+         *  @param[in]  versionId - The id of the rw partition to remove.
          */
         void removeReadWritePartition(std::string versionId);
 


### PR DESCRIPTION
- Use the combine ubimount service file that creates both
  rw and ro partition.

Change-Id: I40438bc16ac4f5734a749b7bf218ea5c6f628339
Signed-off-by: Saqib Khan <khansa@us.ibm.com>